### PR TITLE
Restrict manual auto-host event to authorized users

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -1466,6 +1466,22 @@ local function generateAutomatedRace()
 end
 
 RegisterNetEvent('cw-racingapp:server:newAutoHost', function()
+    local src = source
+    if src and src > 0 then
+        local citizenId = getCitizenId(src)
+        local raceUser = citizenId and RADB.getActiveRacerName(citizenId)
+
+        if not raceUser then
+            NotifyHandler(src, Lang("error_no_user"), 'error')
+            return
+        end
+
+        if not (Config.Permissions[raceUser.auth] and Config.Permissions[raceUser.auth].handleAutoHost) then
+            NotifyHandler(src, Lang("not_auth"), 'error')
+            return
+        end
+    end
+
     generateAutomatedRace()
 end)
 


### PR DESCRIPTION
## What changed
- require `handleAutoHost` permission before allowing `cw-racingapp:server:newAutoHost`
- keep internal/server-triggered auto-host generation working by only gating player-sourced calls

## Why
The manual auto-host UI action was still protected only by the frontend. A client could call `cw-racingapp:server:newAutoHost` directly and force-generate an automated race without having access to the admin auto-host controls.

## How I checked it
- traced the admin UI path from `UINewAutoHost` into `server/main.lua`
- compared it to the existing guarded `toggleAutoHost` callback
- ran `luac -p server/main.lua`
- ran `git diff --check`