### PR TITLE
Guard recent race results against deleted tracks

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -1760,7 +1760,8 @@ RegisterServerCallback('cw-racingapp:server:getRaceResults', function(source, am
     local limit = amount or 10
     local result = RESDB.getRecentRaces(limit)
     for i, track in ipairs(result) do
-        result[i].raceName = Tracks[track.trackId].RaceName
+        local existingTrack = Tracks[track.trackId]
+        result[i].raceName = existingTrack and existingTrack.RaceName or (track.raceName or ('Track #' .. tostring(track.trackId)))
     end
 
     for i, race in ipairs(CompletedRacesOneRacer) do


### PR DESCRIPTION
## What changed
- guard `getRaceResults` against deleted or missing tracks
- keep recent race entries readable by falling back to the stored race name or a simple `Track #id` label

## Why
`getRaceResults` assumed every historical result still had a live entry in `Tracks`. If a track was deleted after races had already been recorded, the recent-results callback could nil-index `Tracks[track.trackId].RaceName` and break the results page.

## How I checked it
- traced the recent results flow from `UiGetRacingResults` into `server:getRaceResults`
- confirmed the callback dereferenced `Tracks[track.trackId]` without a nil guard
- ran `luac -p server/main.lua`
- ran `git diff --check`